### PR TITLE
ES-10: Hide fees in donation form for certain payment methods

### DIFF
--- a/templates/tamaro.twig
+++ b/templates/tamaro.twig
@@ -280,7 +280,7 @@
 					"then": 2
 				},
 				{
-					"if": "paymentMethod() == dd", // DD & LSV
+					"if": "paymentMethod() == direct_debit", // DD & LSV
 					"then": 0
 				},
 				5
@@ -296,9 +296,12 @@
 		let tamaroFullForm = false;
 
 		window.rnw.tamaro.events.paymentMethodChanged.subscribe(function (event) {
+			tamaroPaymentMethod = event.data.api.paymentForm.data.payment_method;
+
+			console.log("changed payment method to " + tamaroPaymentMethod);
 			if (tamaroFullForm) {
 				// Hide the cover fees block for payment methods that have 0% fees
-				if (tamaroPaymentMethod === 'chqr' || tamaroPaymentMethod === 'dd') {
+				if (tamaroPaymentMethod === 'chqr' || tamaroPaymentMethod === 'direct_debit') {
 					rnw.tamaro.instance.config.forceShowBlocks = {
 						payment_cover_fee: false
 					};


### PR DESCRIPTION
Hide fees block in donation forms when payment method is either direct debit or QR payment slip.